### PR TITLE
Add filter for multiplatform aggregated dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "1.3.0
 [libraries]
 nexus-publish = { group = "io.github.gradle-nexus" , name = "publish-plugin", version = "1.3.0" }
 protobuf = { group = "com.google.protobuf", name = "protobuf-gradle-plugin", version = "0.9.4" }
+# TODO: licenses plugin should be updated to version > 2.7. It contains changes required for BOM resolution. But 2.7 contains a bug and cannot be used
 licenses = { group = "com.github.jk1.dependency-license-report", name = "com.github.jk1.dependency-license-report.gradle.plugin", version = "2.5" }
 download = { group = "de.undercouch.download", name = "de.undercouch.download.gradle.plugin", version = "5.6.0" }
 git-properties = { group = "com.gorylenko.gradle-git-properties", name = "gradle-git-properties", version = "2.4.1" }

--- a/plugin/src/functionalTest/kotlin/com/exactpro/th2/gradle/Th2BaseGradlePluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/exactpro/th2/gradle/Th2BaseGradlePluginFunctionalTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertNotNull
+
+class Th2BaseGradlePluginFunctionalTest {
+    @field:TempDir
+    lateinit var projectDir: File
+
+    private val buildFile by lazy { projectDir.resolve("build.gradle") }
+    private val settingsFile by lazy { projectDir.resolve("settings.gradle") }
+
+    @Test
+    fun `licenses plugin finds license for kotlin multiplaform dependencies`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "test"
+            """.trimIndent(),
+        )
+        buildFile.writeText(
+            """
+            plugins {
+                id('java-library')
+                id('org.jetbrains.kotlin.jvm') version '1.8.22'
+                id('com.exactpro.th2.gradle.base')
+            }
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                implementation 'io.ktor:ktor-server:2.3.3'
+            }
+            """.trimIndent(),
+        )
+
+        val result =
+            GradleRunner.create()
+                .forwardOutput()
+                .withDebug(true)
+                .withConfiguredVersion()
+                .withPluginClasspath()
+                .withProjectDir(projectDir)
+                .withArguments(
+                    "--stacktrace",
+                    "checkLicense",
+                    // because no git repository exist in test
+                    "-x",
+                    "generateGitProperties",
+                )
+                .build()
+        val checkLicenses = result.task(":checkLicense")
+        assertNotNull(checkLicenses, "task checkLicense was not executed") {
+            assertEquals(TaskOutcome.SUCCESS, it.outcome, "unexpected task result")
+        }
+    }
+}

--- a/plugin/src/main/kotlin/com/exactpro/th2/gradle/BaseTh2Plugin.kt
+++ b/plugin/src/main/kotlin/com/exactpro/th2/gradle/BaseTh2Plugin.kt
@@ -17,6 +17,7 @@
 package com.exactpro.th2.gradle
 
 import com.exactpro.th2.gradle.config.Libraries
+import com.exactpro.th2.gradle.licenses.MultiplatformDependenciesFilter
 import com.github.jk1.license.LicenseReportExtension
 import com.github.jk1.license.LicenseReportPlugin
 import com.github.jk1.license.filter.LicenseBundleNormalizer
@@ -99,8 +100,16 @@ class BaseTh2Plugin : Plugin<Project> {
                     overwrite(false)
                 }.execute().get()
             }
+            // this configuration is added because of kotlin multiplatform dependencies
+            // the original dependency specified in `dependencies` block goes only into `*Metadata` configuration
+            // because of that when plugin collecting licenses it does not find dependencies it should
+            configurations += "implementationDependenciesMetadata"
 
-            filters = arrayOf(LicenseBundleNormalizer(licenseNormalizerBundlePath.path, false))
+            filters =
+                arrayOf(
+                    LicenseBundleNormalizer(licenseNormalizerBundlePath.path, false),
+                    MultiplatformDependenciesFilter,
+                )
             renderers = arrayOf(JsonReportRenderer("licenses.json", false))
             excludeOwnGroup = true
             allowedLicensesFile = URL("$BASE_EXTERNAL_CONFIGURATION_URL/license-compliance/gradle-license-report/allowed-licenses.json")

--- a/plugin/src/main/kotlin/com/exactpro/th2/gradle/licenses/MultiplatformDependenciesFilter.kt
+++ b/plugin/src/main/kotlin/com/exactpro/th2/gradle/licenses/MultiplatformDependenciesFilter.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.gradle.licenses
+
+import com.github.jk1.license.ModuleData
+import com.github.jk1.license.ProjectData
+import com.github.jk1.license.filter.DependencyFilter
+import org.gradle.api.logging.Logging
+
+/**
+ * Class attempts to find metadata dependencies for multiplatform libraries
+ * and update their licenses data based on the resolved 'twin'
+ *
+ * For examples,
+ *
+ * If `io.ktor:ktor-server:2.3.3` dependency is specified for JVM project
+ * the actual dependency will be `io.ktor:ktor-server-jvm:2.3.3`.
+ *
+ * Because of that we can find all the dependencies that does not have licenses metadata
+ * and have a dependency with `-jvm` suffix in module name.
+ *
+ *
+ * The reason this filter is required because some of the 'aggregated' dependencies does not result into an artifact.
+ * Because of that the licenses plugin cannot find any metadata for them and produces empty [ModuleData] object.
+ */
+internal object MultiplatformDependenciesFilter : DependencyFilter {
+    override fun filter(source: ProjectData): ProjectData {
+        source.configurations.forEach { configuration ->
+            LOGGER.info("Processing configuration {}", configuration.name)
+            configuration.dependencies
+                .asSequence()
+                .filter(ModuleData::isEmpty)
+                .forEach moduleForEach@{ module ->
+                    val expectedModuleName = "${module.name}-jvm"
+                    val twinModule =
+                        configuration.dependencies.find {
+                            it.group == module.group && it.name == expectedModuleName && it.version == module.version
+                        } ?: return@moduleForEach
+                    LOGGER.info(
+                        "Found 'twin' dependency {}:{}:{} for {}. Updating licenses data",
+                        twinModule.group,
+                        twinModule.name,
+                        twinModule.version,
+                        module,
+                    )
+                    module.poms.addAll(twinModule.poms)
+                    module.licenseFiles.addAll(twinModule.licenseFiles)
+                    module.manifests.addAll(twinModule.manifests)
+                }
+        }
+        return source
+    }
+
+    private val LOGGER = Logging.getLogger(MultiplatformDependenciesFilter::class.java)
+}


### PR DESCRIPTION
Because of kotlin multiplatform dependencies not all dependencies are resolved into any artifact. The license plugin we use cannot work with dependencies without an artifact that is resolved into `null` license metadata.
But all those dependencies have a 'twin' with the same group, version, and '{module}-jvm` module name. This allows us find those 'twin and use their metadata for original dependency.