### PR TITLE
Add validation for publication parameters 

### DIFF
--- a/plugin/src/functionalTest/kotlin/com/exactpro/th2/gradle/Th2PublishGradlePluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/exactpro/th2/gradle/Th2PublishGradlePluginFunctionalTest.kt
@@ -18,11 +18,14 @@ package com.exactpro.th2.gradle
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import kotlin.test.assertContains
 
 class Th2PublishGradlePluginFunctionalTest {
     @field:TempDir
@@ -42,6 +45,10 @@ class Th2PublishGradlePluginFunctionalTest {
                 id('maven-publish')
                 id('com.exactpro.th2.gradle.publish')
             }
+            
+            group = "com.example"
+            version = "1.0.0"
+            description = "test description"
             
             th2Publish {
               pom {
@@ -94,6 +101,10 @@ class Th2PublishGradlePluginFunctionalTest {
                 id('maven-publish')
                 id('com.exactpro.th2.gradle.publish')
             }
+            
+            group = "com.example"
+            version = "1.0.0"
+            description = "test description"
             """.trimIndent(),
         )
 
@@ -112,7 +123,7 @@ class Th2PublishGradlePluginFunctionalTest {
                         "ORG_GRADLE_PROJECT_signingPassword" to "signPassword",
                     ),
                 )
-                .withArguments("--stacktrace", "tasks")
+                .withArguments("--stacktrace", "tasks", "-Pvcs_url=test")
                 .build()
 
         // Verify the result
@@ -126,6 +137,221 @@ class Th2PublishGradlePluginFunctionalTest {
             {
                 result.assertHasTask("closeAndReleaseSonatypeStagingRepository")
             },
+        )
+    }
+
+    @Test
+    fun `reports error if version is missing`() {
+        // Set up the test build
+        settingsFile.writeText(
+            """
+            rootProject.name = "test"
+            """.trimIndent(),
+        )
+        buildFile.writeText(
+            """
+            plugins {
+                id('java')
+                id('maven-publish')
+                id('com.exactpro.th2.gradle.publish')
+            }
+            
+            group = "com.example"
+            // version = "1.0.0"
+            description = "test description"
+            th2Publish {
+              pom {
+                vcsUrl.set("test")
+              }
+            }
+            """.trimIndent(),
+        )
+
+        val exception =
+            assertThrows<UnexpectedBuildFailure> {
+                GradleRunner.create()
+                    .forwardOutput()
+                    .withPluginClasspath()
+                    .withConfiguredVersion()
+                    .withProjectDir(projectDir)
+                    .withEnvironment(
+                        mapOf(
+                            "ORG_GRADLE_PROJECT_sonatypeUsername" to "user",
+                            "ORG_GRADLE_PROJECT_sonatypePassword" to "pwd",
+                            "ORG_GRADLE_PROJECT_signingKey" to "signKey",
+                            "ORG_GRADLE_PROJECT_signingPassword" to "signPassword",
+                        ),
+                    )
+                    .withArguments("--stacktrace", "tasks")
+                    .build()
+            }
+
+        assertContains(
+            exception.buildResult.output,
+            """
+            project 'test' contains following issues:
+            version is not provided (use version property)
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `reports error if group is empty`() {
+        // Set up the test build
+        settingsFile.writeText(
+            """
+            rootProject.name = "test"
+            """.trimIndent(),
+        )
+        buildFile.writeText(
+            """
+            plugins {
+                id('java')
+                id('maven-publish')
+                id('com.exactpro.th2.gradle.publish')
+            }
+            
+            group = ""
+            version = "1.0.0"
+            description = "test description"
+            th2Publish {
+              pom {
+                vcsUrl.set("test")
+              }
+            }
+            """.trimIndent(),
+        )
+
+        val exception =
+            assertThrows<UnexpectedBuildFailure> {
+                GradleRunner.create()
+                    .forwardOutput()
+                    .withPluginClasspath()
+                    .withConfiguredVersion()
+                    .withProjectDir(projectDir)
+                    .withEnvironment(
+                        mapOf(
+                            "ORG_GRADLE_PROJECT_sonatypeUsername" to "user",
+                            "ORG_GRADLE_PROJECT_sonatypePassword" to "pwd",
+                            "ORG_GRADLE_PROJECT_signingKey" to "signKey",
+                            "ORG_GRADLE_PROJECT_signingPassword" to "signPassword",
+                        ),
+                    )
+                    .withArguments("--stacktrace", "tasks")
+                    .build()
+            }
+
+        assertContains(
+            exception.buildResult.output,
+            """
+            project 'test' contains following issues:
+            group is not provided (use group property)
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `reports error if descriptoin is missing`() {
+        // Set up the test build
+        settingsFile.writeText(
+            """
+            rootProject.name = "test"
+            """.trimIndent(),
+        )
+        buildFile.writeText(
+            """
+            plugins {
+                id('java')
+                id('maven-publish')
+                id('com.exactpro.th2.gradle.publish')
+            }
+            
+            group = "com.example"
+            version = "1.0.0"
+            //description = "test description"
+            th2Publish {
+              pom {
+                vcsUrl.set("test")
+              }
+            }
+            """.trimIndent(),
+        )
+
+        val exception =
+            assertThrows<UnexpectedBuildFailure> {
+                GradleRunner.create()
+                    .forwardOutput()
+                    .withPluginClasspath()
+                    .withConfiguredVersion()
+                    .withProjectDir(projectDir)
+                    .withEnvironment(
+                        mapOf(
+                            "ORG_GRADLE_PROJECT_sonatypeUsername" to "user",
+                            "ORG_GRADLE_PROJECT_sonatypePassword" to "pwd",
+                            "ORG_GRADLE_PROJECT_signingKey" to "signKey",
+                            "ORG_GRADLE_PROJECT_signingPassword" to "signPassword",
+                        ),
+                    )
+                    .withArguments("--stacktrace", "tasks")
+                    .build()
+            }
+
+        assertContains(
+            exception.buildResult.output,
+            """
+            project 'test' contains following issues:
+            description is not provided (use description property)
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `reports error if vcs url is missing`() {
+        // Set up the test build
+        settingsFile.writeText(
+            """
+            rootProject.name = "test"
+            """.trimIndent(),
+        )
+        buildFile.writeText(
+            """
+            plugins {
+                id('java')
+                id('maven-publish')
+                id('com.exactpro.th2.gradle.publish')
+            }
+            
+            group = "com.example"
+            version = "1.0.0"
+            description = "test description"
+            """.trimIndent(),
+        )
+
+        val exception =
+            assertThrows<UnexpectedBuildFailure> {
+                GradleRunner.create()
+                    .forwardOutput()
+                    .withPluginClasspath()
+                    .withConfiguredVersion()
+                    .withProjectDir(projectDir)
+                    .withEnvironment(
+                        mapOf(
+                            "ORG_GRADLE_PROJECT_sonatypeUsername" to "user",
+                            "ORG_GRADLE_PROJECT_sonatypePassword" to "pwd",
+                            "ORG_GRADLE_PROJECT_signingKey" to "signKey",
+                            "ORG_GRADLE_PROJECT_signingPassword" to "signPassword",
+                        ),
+                    )
+                    .withArguments("--stacktrace", "tasks")
+                    .build()
+            }
+
+        assertContains(
+            exception.buildResult.output,
+            """
+            project 'test' contains following issues:
+            vcs url is not provided (use th2Publish.pom extension or vcs_url property)
+            """.trimIndent(),
         )
     }
 

--- a/plugin/src/main/kotlin/com/exactpro/th2/gradle/ComponentTh2Plugin.kt
+++ b/plugin/src/main/kotlin/com/exactpro/th2/gradle/ComponentTh2Plugin.kt
@@ -18,6 +18,7 @@ package com.exactpro.th2.gradle
 
 import com.palantir.gradle.docker.DockerExtension
 import com.palantir.gradle.docker.PalantirDockerPlugin
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.distribution.plugins.DistributionPlugin
@@ -41,6 +42,12 @@ class ComponentTh2Plugin : Plugin<Project> {
             }
             tasks.getByName("dockerPrepare")
                 .dependsOn(tasks.getByName(DistributionPlugin.TASK_INSTALL_NAME))
+
+            afterEvaluate {
+                if (version.toString().let { it == Project.DEFAULT_VERSION || it.isEmpty() }) {
+                    throw GradleException("project '$name' missing version (use version property to provide the version)")
+                }
+            }
         }
     }
 }

--- a/plugin/src/test/kotlin/com/exactpro/th2/gradle/PublishTh2PluginTest.kt
+++ b/plugin/src/test/kotlin/com/exactpro/th2/gradle/PublishTh2PluginTest.kt
@@ -43,6 +43,8 @@ internal class PublishTh2PluginTest {
         project.pluginManager.apply("maven-publish")
         project.pluginManager.apply("com.exactpro.th2.gradle.publish")
 
+        project.group = "com.example"
+        project.version = "1.0.0"
         project.description = "test description"
         project.extensions.findByType<PublishTh2Extension>().apply {
             assertNotNull(this, "no publish th2 extension applied")


### PR DESCRIPTION
Validate group, version, description, vcs url when they are required. Prevents getting unexpected errors when publishing to sonatype or building a Docker image using `dockerPrepare` task