### PR TITLE
[TH2-5270] Remove dependency to docker-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,6 @@ Third-party plugins applied under the hood:
 This plugin prepares the project to be packaged as Docker image.
 The project **MUST** use `application` plugin to package the component.
 
-Third-party plugins applied under the hood:
-
-- [com.palantir.docker](https://github.com/palantir/gradle-docker)
-
 ## Apply from Sonatype repository
 
 Until this plugin is not published to Gradle portal it can be applied from Sonatype repository.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,6 @@ licenses = { group = "com.github.jk1.dependency-license-report", name = "com.git
 download = { group = "de.undercouch.download", name = "de.undercouch.download.gradle.plugin", version = "5.6.0" }
 git-properties = { group = "com.gorylenko.gradle-git-properties", name = "gradle-git-properties", version = "2.4.2" }
 owasp = { group = "org.owasp", name = "dependency-check-gradle", version = "10.0.4" }
-docker = { group = "com.palantir.gradle.docker", name = "gradle-docker", version = "0.36.0" }
 junit-bom = { group = "org.junit", name = "junit-bom", version = "5.11.4" }
 junit-parameters = { group = "org.junit.jupiter", name = "junit-jupiter-params" }
 junit-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
 
     implementation(libs.owasp)
 
-    implementation(libs.docker)
     // Use the Kotlin JUnit 5 integration.
     testImplementation(gradleTestKit())
     testImplementation(platform(libs.junit.bom))

--- a/plugin/src/functionalTest/kotlin/com/exactpro/th2/gradle/Th2BaseGradlePluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/exactpro/th2/gradle/Th2BaseGradlePluginFunctionalTest.kt
@@ -61,8 +61,8 @@ class Th2BaseGradlePluginFunctionalTest {
             }
             
             dependencies {
-                implementation platform('io.ktor:ktor-bom:2.3.3')
-                implementation 'io.ktor:ktor-server'
+                implementation(platform('io.ktor:ktor-bom:2.3.3'))
+                implementation('io.ktor:ktor-server')
             }
             """.trimIndent(),
         )
@@ -120,8 +120,8 @@ class Th2BaseGradlePluginFunctionalTest {
             }
             
             dependencies {
-                implementation platform('io.ktor:ktor-bom:2.3.3')
-                implementation 'io.ktor:ktor-server'
+                implementation(platform('io.ktor:ktor-bom:2.3.3'))
+                implementation('io.ktor:ktor-server')
             }
             """.trimIndent(),
         )

--- a/plugin/src/functionalTest/kotlin/com/exactpro/th2/gradle/Th2ComponentGradlePluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/exactpro/th2/gradle/Th2ComponentGradlePluginFunctionalTest.kt
@@ -56,12 +56,12 @@ class Th2ComponentGradlePluginFunctionalTest {
             repositories {
                 mavenCentral()
                 maven {
-                    name 'Sonatype_snapshots'
-                    url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+                    name = 'Sonatype_snapshots'
+                    url = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
                 }
                 maven {
-                    name 'Sonatype_releases'
-                    url 'https://s01.oss.sonatype.org/content/repositories/releases/'
+                    name = 'Sonatype_releases'
+                    url = 'https://s01.oss.sonatype.org/content/repositories/releases/'
                 }
             }
             
@@ -122,12 +122,12 @@ class Th2ComponentGradlePluginFunctionalTest {
             repositories {
                 mavenCentral()
                 maven {
-                    name 'Sonatype_snapshots'
-                    url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+                    name = 'Sonatype_snapshots'
+                    url = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
                 }
                 maven {
-                    name 'Sonatype_releases'
-                    url 'https://s01.oss.sonatype.org/content/repositories/releases/'
+                    name = 'Sonatype_releases'
+                    url = 'https://s01.oss.sonatype.org/content/repositories/releases/'
                 }
             }
             

--- a/plugin/src/functionalTest/kotlin/com/exactpro/th2/gradle/Th2ComponentGradlePluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/exactpro/th2/gradle/Th2ComponentGradlePluginFunctionalTest.kt
@@ -41,6 +41,9 @@ class Th2ComponentGradlePluginFunctionalTest {
             rootProject.name = "test"
             """.trimIndent(),
         )
+
+        val extraFile = "extra.txt"
+
         buildFile.writeText(
             """
             plugins {
@@ -65,8 +68,14 @@ class Th2ComponentGradlePluginFunctionalTest {
             application {
                 mainClass.set('test.Main')
             }
+            
+            docker {
+                copySpec.from("$extraFile")
+            }
             """.trimIndent(),
         )
+
+        projectDir.resolve(extraFile).writeText("Hello World!")
 
         val result =
             GradleRunner.create()
@@ -90,6 +99,9 @@ class Th2ComponentGradlePluginFunctionalTest {
         assertAll(
             { assertEquals(TaskOutcome.SUCCESS, result.task(":dockerPrepare")?.outcome, "unexpected preparation result") },
             { assertFileExist(dockerDirectory / "service") },
+            { assertFileExist(dockerDirectory / "service" / "bin") },
+            { assertFileExist(dockerDirectory / "service" / "lib") },
+            { assertFileExist(dockerDirectory / extraFile) },
         )
     }
 

--- a/plugin/src/functionalTest/kotlin/com/exactpro/th2/gradle/Th2GrpcGradlePluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/exactpro/th2/gradle/Th2GrpcGradlePluginFunctionalTest.kt
@@ -20,13 +20,12 @@ import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
-import org.junit.jupiter.api.io.CleanupMode
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import kotlin.test.assertEquals
 
 class Th2GrpcGradlePluginFunctionalTest {
-    @field:TempDir(cleanup = CleanupMode.ON_SUCCESS)
+    @field:TempDir
     lateinit var projectDir: File
 
     @Test
@@ -48,12 +47,12 @@ class Th2GrpcGradlePluginFunctionalTest {
             repositories {
                 mavenCentral()
                 maven {
-                    name 'Sonatype_snapshots'
-                    url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+                    name = 'Sonatype_snapshots'
+                    url = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
                 }
                 maven {
-                    name 'Sonatype_releases'
-                    url 'https://s01.oss.sonatype.org/content/repositories/releases/'
+                    name = 'Sonatype_releases'
+                    url = 'https://s01.oss.sonatype.org/content/repositories/releases/'
                 }
             }
             """.trimIndent(),
@@ -101,8 +100,8 @@ class Th2GrpcGradlePluginFunctionalTest {
             repositories {
                 mavenCentral()
                 maven {
-                    name 'Sonatype_snapshots'
-                    url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+                    name = 'Sonatype_snapshots'
+                    url = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
                 }
                 maven {
                     name 'Sonatype_releases'
@@ -165,12 +164,12 @@ class Th2GrpcGradlePluginFunctionalTest {
                 repositories {
                     mavenCentral()
                     maven {
-                        name 'Sonatype_snapshots'
-                        url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
+                        name = 'Sonatype_snapshots'
+                        url = 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
                     }
                     maven {
-                        name 'Sonatype_releases'
-                        url 'https://s01.oss.sonatype.org/content/repositories/releases/'
+                        name = 'Sonatype_releases'
+                        url = 'https://s01.oss.sonatype.org/content/repositories/releases/'
                     }
                 }
             }

--- a/plugin/src/main/kotlin/com/exactpro/th2/gradle/ComponentTh2Plugin.kt
+++ b/plugin/src/main/kotlin/com/exactpro/th2/gradle/ComponentTh2Plugin.kt
@@ -42,9 +42,10 @@ class ComponentTh2Plugin : Plugin<Project> {
 
             val dockerDir = project.layout.buildDirectory.dir("docker")
 
-            val dockerClean = tasks.register<Delete>("dockerClean") {
-                delete(dockerDir)
-            }
+            val dockerClean =
+                tasks.register<Delete>("dockerClean") {
+                    delete(dockerDir)
+                }
 
             tasks.register<Copy>("dockerPrepare") {
                 dependsOn(tasks.getByName(DistributionPlugin.TASK_INSTALL_NAME), dockerClean)

--- a/plugin/src/main/kotlin/com/exactpro/th2/gradle/DockerTh2Extension.kt
+++ b/plugin/src/main/kotlin/com/exactpro/th2/gradle/DockerTh2Extension.kt
@@ -24,6 +24,8 @@ import javax.inject.Inject
  * [DockerTh2Extension] emulates the extension from [https://github.com/palantir/gradle-docker] plugin
  * that was used before. Right now it is no longer supported and we removed it from our dependencies
  */
-abstract class DockerTh2Extension @Inject constructor(private val project: Project) {
-    val copySpec: CopySpec = project.copySpec()
-}
+abstract class DockerTh2Extension
+    @Inject
+    constructor(private val project: Project) {
+        val copySpec: CopySpec = project.copySpec()
+    }

--- a/plugin/src/main/kotlin/com/exactpro/th2/gradle/DockerTh2Extension.kt
+++ b/plugin/src/main/kotlin/com/exactpro/th2/gradle/DockerTh2Extension.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Exactpro (Exactpro Systems Limited)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.exactpro.th2.gradle
+
+import org.gradle.api.Project
+import org.gradle.api.file.CopySpec
+import javax.inject.Inject
+
+/**
+ * [DockerTh2Extension] emulates the extension from [https://github.com/palantir/gradle-docker] plugin
+ * that was used before. Right now it is no longer supported and we removed it from our dependencies
+ */
+abstract class DockerTh2Extension @Inject constructor(private val project: Project) {
+    val copySpec: CopySpec = project.copySpec()
+}

--- a/plugin/src/main/kotlin/com/exactpro/th2/gradle/DockerTh2Extension.kt
+++ b/plugin/src/main/kotlin/com/exactpro/th2/gradle/DockerTh2Extension.kt
@@ -26,6 +26,6 @@ import javax.inject.Inject
  */
 abstract class DockerTh2Extension
     @Inject
-    constructor(private val project: Project) {
+    constructor(project: Project) {
         val copySpec: CopySpec = project.copySpec()
     }

--- a/plugin/src/test/kotlin/com/exactpro/th2/gradle/ComponentTh2PluginTest.kt
+++ b/plugin/src/test/kotlin/com/exactpro/th2/gradle/ComponentTh2PluginTest.kt
@@ -43,12 +43,6 @@ class ComponentTh2PluginTest {
             },
             {
                 assertTrue(
-                    project.plugins.hasPlugin(PalantirDockerPlugin::class.java),
-                    "docker plugin was not applied",
-                )
-            },
-            {
-                assertTrue(
                     project.tasks.getByName("dockerPrepare").dependsOn
                         .contains(project.tasks.getByName("installDist")),
                     "installDist dependency was not added to docker task",

--- a/plugin/src/test/kotlin/com/exactpro/th2/gradle/ComponentTh2PluginTest.kt
+++ b/plugin/src/test/kotlin/com/exactpro/th2/gradle/ComponentTh2PluginTest.kt
@@ -16,7 +16,6 @@
 
 package com.exactpro.th2.gradle
 
-import com.palantir.gradle.docker.PalantirDockerPlugin
 import org.gradle.api.plugins.ApplicationPlugin
 import org.gradle.api.plugins.JavaApplication
 import org.gradle.kotlin.dsl.the
@@ -24,6 +23,8 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class ComponentTh2PluginTest {
@@ -40,6 +41,14 @@ class ComponentTh2PluginTest {
                     project.plugins.hasPlugin(ApplicationPlugin::class.java),
                     "application plugin was not applied",
                 )
+            },
+            {
+                assertNotNull(
+                    project.extensions.findByName("docker"),
+                    "no 'docker' extension found",
+                ) {
+                    assertIs<DockerTh2Extension>(it, "incorrect extension type")
+                }
             },
             {
                 assertTrue(


### PR DESCRIPTION
The docker-plugin is no longer supported and is not compatible with Gradle >=8.12. To avoid any issues in the future we have migrated the required functionality inside our gradle plugin