### PR TITLE
Explicitly specify the JVM version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,11 +11,15 @@ jobs:
     steps:
       - name: Checkout project sources
         uses: actions/checkout@v4
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 11
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
          gradle-version: wrapper
+         validate-wrappers: 'true'
       - name: Run build with Gradle
         run: ./gradlew clean build --info

--- a/.github/workflows/publish-gradle-plugin.yml
+++ b/.github/workflows/publish-gradle-plugin.yml
@@ -38,12 +38,16 @@ jobs:
     steps:
       - name: Checkout project sources
         uses: actions/checkout@v4
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 11
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: wrapper
+          validate-wrappers: 'true'
       - name: Publish plugins to Gradle portal
         run: >
           ./gradlew clean build publishPlugins --info
@@ -55,12 +59,16 @@ jobs:
     steps:
       - name: Checkout project sources
         uses: actions/checkout@v4
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 11
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: wrapper
+          validate-wrappers: 'true'
       - name: Publish plugins to Gradle portal
         run: >
           ./gradlew clean build publishToSonatype closeAndReleaseStagingRepositories --info

--- a/.github/workflows/verify-publish-configuration.yml
+++ b/.github/workflows/verify-publish-configuration.yml
@@ -13,12 +13,16 @@ jobs:
     steps:
       - name: Checkout project sources
         uses: actions/checkout@v4
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 11
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: wrapper
+          validate-wrappers: 'true'
       - name: Validate Gradle portal publication configuration
         run: >
           ./gradlew clean publishPlugins --info --validate-only

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.util.capitalizeDecapitalize.capitalizeAsciiOnly
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
@@ -11,6 +12,18 @@ plugins {
     alias(libs.plugins.build.config)
     alias(libs.plugins.ktlint)
     alias(libs.plugins.gradle.functional.test)
+}
+
+java {
+    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_11
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_11
+        freeCompilerArgs.add("-Xjdk-release=11")
+    }
 }
 
 repositories {


### PR DESCRIPTION
By default, setup-gradle action uses Java 17. But we need to compile our plugins with Java 11 for now.

Also, this PR adds parameters to always compile the classes for Java 11 (no matter which Jvm is used - 11 or above)