### PR TITLE
Updated owasp gradle plugin to 12.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ protobuf = { group = "com.google.protobuf", name = "protobuf-gradle-plugin", ver
 licenses = { group = "com.github.jk1.dependency-license-report", name = "com.github.jk1.dependency-license-report.gradle.plugin", version = "2.8" }
 download = { group = "de.undercouch.download", name = "de.undercouch.download.gradle.plugin", version = "5.6.0" }
 git-properties = { group = "com.gorylenko.gradle-git-properties", name = "gradle-git-properties", version = "2.4.2" }
-owasp = { group = "org.owasp", name = "dependency-check-gradle", version = "12.0.2" }
+owasp = { group = "org.owasp", name = "dependency-check-gradle", version = "12.1.0" }
 junit-bom = { group = "org.junit", name = "junit-bom", version = "5.11.4" }
 junit-parameters = { group = "org.junit.jupiter", name = "junit-jupiter-params" }
 junit-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }


### PR DESCRIPTION
The problem `Dependency check fails: Error updating the NVD Data / SAFETY` is fixed in 12.1.0 version of owasp gradle plugin  
https://github.com/dependency-check/DependencyCheck/issues/7411