### PR TITLE
Fixed base plugin configuration when targetJavaVersion is 1.8

### DIFF
--- a/plugin/src/functionalTest/kotlin/com/exactpro/th2/gradle/Th2BaseGradlePluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/exactpro/th2/gradle/Th2BaseGradlePluginFunctionalTest.kt
@@ -93,7 +93,8 @@ class Th2BaseGradlePluginFunctionalTest {
         }
 
         val result =
-            GradleRunner.create()
+            GradleRunner
+                .create()
                 .forwardOutput()
                 .withDebug(true)
                 .withConfiguredVersion()
@@ -105,8 +106,7 @@ class Th2BaseGradlePluginFunctionalTest {
                     // because no git repository exist in test
                     "-x",
                     "generateGitProperties",
-                )
-                .build()
+                ).build()
 
         assertAll(
             { assertEquals(TaskOutcome.SUCCESS, result.task(":compileKotlin")?.outcome, "unexpected kotlin compile outcome") },
@@ -114,6 +114,79 @@ class Th2BaseGradlePluginFunctionalTest {
             { assertEquals(TaskOutcome.SUCCESS, result.task(":build")?.outcome, "unexpected build outcome") },
             { assertClassVersion("java", "Hello.class", 61) },
             { assertClassVersion("kotlin", "MainKt.class", 61) },
+        )
+    }
+
+    @Test
+    fun `the target jvm release version is 1 dot 8`() {
+        settingsFile.writeText(
+            """
+            rootProject.name = "test"
+            """.trimIndent(),
+        )
+        buildFile.writeText(
+            """
+            plugins {
+                id('java-library')
+                id('org.jetbrains.kotlin.jvm') version '1.9.0'
+                id('com.exactpro.th2.gradle.base')
+            }
+            
+            th2JavaRelease {
+              targetJavaVersion.set(JavaVersion.VERSION_1_8)
+            }
+            
+            repositories {
+                mavenCentral()
+            }
+            """.trimIndent(),
+        )
+        with(projectDir / "src" / "main" / "java") {
+            mkdirs()
+            resolve("Hello.java").writeText(
+                """
+                class Hello {
+                  public static void printHello() {
+                    System.out.println("Hello World from Java!");
+                  }
+                }
+                """.trimIndent(),
+            )
+        }
+        with(projectDir / "src" / "main" / "kotlin") {
+            mkdirs()
+            resolve("Main.kt").writeText(
+                """
+                fun main() {
+                  println("Hello World from Kotlin!")
+                  Hello.printHello()
+                }
+                """.trimIndent(),
+            )
+        }
+
+        val result =
+            GradleRunner
+                .create()
+                .forwardOutput()
+                .withDebug(true)
+                .withConfiguredVersion()
+                .withPluginClasspath()
+                .withProjectDir(projectDir)
+                .withArguments(
+                    "--stacktrace",
+                    "build",
+                    // because no git repository exist in test
+                    "-x",
+                    "generateGitProperties",
+                ).build()
+
+        assertAll(
+            { assertEquals(TaskOutcome.SUCCESS, result.task(":compileKotlin")?.outcome, "unexpected kotlin compile outcome") },
+            { assertEquals(TaskOutcome.SUCCESS, result.task(":compileJava")?.outcome, "unexpected java compile outcome") },
+            { assertEquals(TaskOutcome.SUCCESS, result.task(":build")?.outcome, "unexpected build outcome") },
+            { assertClassVersion("java", "Hello.class", 52) },
+            { assertClassVersion("kotlin", "MainKt.class", 52) },
         )
     }
 
@@ -162,7 +235,8 @@ class Th2BaseGradlePluginFunctionalTest {
         }
 
         val result =
-            GradleRunner.create()
+            GradleRunner
+                .create()
                 .forwardOutput()
                 .withDebug(true)
                 .withConfiguredVersion()
@@ -174,8 +248,7 @@ class Th2BaseGradlePluginFunctionalTest {
                     // because no git repository exist in test
                     "-x",
                     "generateGitProperties",
-                )
-                .build()
+                ).build()
 
         assertAll(
             { assertEquals(TaskOutcome.SUCCESS, result.task(":compileKotlin")?.outcome, "unexpected kotlin compile outcome") },
@@ -213,7 +286,8 @@ class Th2BaseGradlePluginFunctionalTest {
         )
 
         val result =
-            GradleRunner.create()
+            GradleRunner
+                .create()
                 .forwardOutput()
                 .withDebug(true)
                 .withConfiguredVersion()
@@ -225,8 +299,7 @@ class Th2BaseGradlePluginFunctionalTest {
                     // because no git repository exist in test
                     "-x",
                     "generateGitProperties",
-                )
-                .build()
+                ).build()
         val checkLicenses = result.task(":checkLicense")
         assertNotNull(checkLicenses, "task checkLicense was not executed") {
             assertEquals(TaskOutcome.SUCCESS, it.outcome, "unexpected task result")
@@ -312,7 +385,8 @@ class Th2BaseGradlePluginFunctionalTest {
             """.trimIndent(),
         )
         val result =
-            GradleRunner.create()
+            GradleRunner
+                .create()
                 .forwardOutput()
                 .withDebug(true)
                 .withConfiguredVersion()
@@ -324,8 +398,7 @@ class Th2BaseGradlePluginFunctionalTest {
                     // because no git repository exist in test
                     "-x",
                     "generateGitProperties",
-                )
-                .build()
+                ).build()
 
         val checkLicenses = result.task(":checkLicense")
         assertNotNull(checkLicenses, "task checkLicense was not executed") {
@@ -371,7 +444,8 @@ class Th2BaseGradlePluginFunctionalTest {
         extraAssertion: (ArrayNode, String) -> Unit = { _, _ -> },
     ) {
         val module =
-            elements().asSequence()
+            elements()
+                .asSequence()
                 .find { it.get("moduleName").textValue() == moduleName }
         assertNotNull(module, "module $moduleName not found") { m ->
             val moduleInfo = assertIs<ObjectNode>(m, "module info must be an object")

--- a/plugin/src/main/kotlin/com/exactpro/th2/gradle/BaseTh2Plugin.kt
+++ b/plugin/src/main/kotlin/com/exactpro/th2/gradle/BaseTh2Plugin.kt
@@ -30,7 +30,6 @@ import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaTestFixturesPlugin
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.jvm.tasks.Jar
-import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.withType
@@ -159,7 +158,7 @@ class BaseTh2Plugin : Plugin<Project> {
         tasks.withType<JavaCompile> {
             options.release.set(
                 javaRelease.targetJavaVersion
-                    .map { JavaLanguageVersion.of(it.toString()).asInt() },
+                    .map { JavaVersion.toVersion(it).majorVersion.toInt() },
             )
         }
     }
@@ -185,14 +184,12 @@ class BaseTh2Plugin : Plugin<Project> {
 
     private fun Project.configureKotlinProject(extension: JavaReleaseTh2Extension) {
         plugins.withId("org.jetbrains.kotlin.jvm") {
-            fun JavaVersion.toJdkTarget() = if (ordinal <= JavaVersion.VERSION_1_8.ordinal) "1.$this" else this.toString()
-
             tasks.withType<KotlinCompile>().configureEach {
                 compilerOptions {
-                    jvmTarget.set(extension.targetJavaVersion.map { JvmTarget.fromTarget(it.toJdkTarget()) })
+                    jvmTarget.set(extension.targetJavaVersion.map { JvmTarget.fromTarget(it.toString()) })
                     freeCompilerArgs.add(
                         extension.targetJavaVersion
-                            .map { "-Xjdk-release=${it.toJdkTarget()}" },
+                            .map { "-Xjdk-release=$it" },
                     )
                 }
             }


### PR DESCRIPTION
Exception example:
```
Caused by: java.lang.IllegalArgumentException: JavaLanguageVersion must be a positive integer, not '1.8'
	at org.gradle.jvm.toolchain.JavaLanguageVersion.of(JavaLanguageVersion.java:37)
	at com.exactpro.th2.gradle.BaseTh2Plugin$configureReleaseParameters$1$1.transform(BaseTh2Plugin.kt:162)
	at com.exactpro.th2.gradle.BaseTh2Plugin$configureReleaseParameters$1$1.transform(BaseTh2Plugin.kt:162)
	at org.gradle.api.internal.provider.ValueSupplier$Present.transform(ValueSupplier.java:519)
	at org.gradle.api.internal.provider.TransformBackedProvider.mapValue(TransformBackedProvider.java:91)
	at org.gradle.api.internal.provider.TransformBackedProvider.calculateOwnValue(TransformBackedProvider.java:82)
	at org.gradle.api.internal.provider.AbstractMinimalProvider.calculatePresence(AbstractMinimalProvider.java:95)
	at org.gradle.api.internal.provider.MappingProvider.calculatePresence(MappingProvider.java:50)
	at org.gradle.api.internal.provider.AbstractProperty.calculatePresence(AbstractProperty.java:81)
	... 164 more
```